### PR TITLE
v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.5 #
+* Fixed bug that caused situations where equality (`==`) in the Pipfile combined
+with a range operator would lead to detection of nonexistent discrepancies.
+
 # v0.2.4 #
 * Updated dependencies - specifically, addressed security concern with bleach v3.1.3
 

--- a/pipenv_devcheck/__version__.py
+++ b/pipenv_devcheck/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "pipenv-devcheck"
 __description__ = "Pipenv/setup.py dependency comparison tool"
 __url__ = "https://github.com/neighborhoods/pipenv-devcheck"
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __author__ = "George Wood (@Geoiv)"
 __author_email__ = "george.wood@55places.com"
 __license__ = "MIT"

--- a/pipenv_devcheck/check_fns.py
+++ b/pipenv_devcheck/check_fns.py
@@ -13,6 +13,9 @@ def check_equality(left_version, right_op, right_version, **_):
             The comparison operator to be used, associated with 'right_version'
         right_version (packaging.version.Version):
             The version on the right side of the comparison
+        **_ (dict):
+            Unused **kwargs. Present to allow this function to accept
+            'left_op' arguments
     Returns:
         bool: Whether or not the check passed
     """

--- a/pipenv_devcheck/check_fns.py
+++ b/pipenv_devcheck/check_fns.py
@@ -22,7 +22,7 @@ def check_equality(left_version, right_op, right_version, **_):
     return operators[right_op](left_version, right_version)
 
 
-def check_inequality(left_version, right_op, pipfile_version):
+def check_inequality(left_version, right_op, pipfile_version, **_):
     """
     Checks for version compatibility when the dependency for
     'left_version' has specified an explicitly disallowed version
@@ -34,6 +34,9 @@ def check_inequality(left_version, right_op, pipfile_version):
             The comparison operator to be used, associated with 'right_version'
         pipfile_version (packaging.version.Version):
             The version specified in the Pipfile
+        **_ (dict):
+            Unused **kwargs. Present to allow this function to accept
+            'left_op' arguments
     Returns:
         bool: Whether or not the check passed
     """

--- a/pipenv_devcheck/check_fns.py
+++ b/pipenv_devcheck/check_fns.py
@@ -22,7 +22,7 @@ def check_equality(left_version, right_op, right_version, **_):
     return operators[right_op](left_version, right_version)
 
 
-def check_inequality(left_version, right_op, pipfile_version, **_):
+def check_inequality(left_version, right_op, right_version, **_):
     """
     Checks for version compatibility when the dependency for
     'left_version' has specified an explicitly disallowed version
@@ -32,8 +32,8 @@ def check_inequality(left_version, right_op, pipfile_version, **_):
             The version on the left side of the comparison
         right_op (str):
             The comparison operator to be used, associated with 'right_version'
-        pipfile_version (packaging.version.Version):
-            The version specified in the Pipfile
+        right_version (packaging.version.Version):
+            The version on the right side of the comparison
         **_ (dict):
             Unused **kwargs. Present to allow this function to accept
             'left_op' arguments
@@ -42,7 +42,7 @@ def check_inequality(left_version, right_op, pipfile_version, **_):
     """
     inclusive_ops = ["==", ">=", "=>", "<="]
     return not (right_op in inclusive_ops and
-                left_version == pipfile_version)
+                left_version == right_version)
 
 
 def check_range(left_op, left_version, right_op, right_version):

--- a/pipenv_devcheck/check_fns.py
+++ b/pipenv_devcheck/check_fns.py
@@ -1,7 +1,7 @@
 import operator
 
 
-def check_equality(left_version, right_op, right_version):
+def check_equality(left_version, right_op, right_version, **_):
     """
     Checks for version compatibility when the dependency for
     'left_version' has specified an exact version

--- a/pipenv_devcheck/check_fns.py
+++ b/pipenv_devcheck/check_fns.py
@@ -1,70 +1,75 @@
 import operator
 
 
-def check_equality(setup_version, pipfile_op, pipfile_version):
+def check_equality(left_version, right_op, right_version):
     """
-    Checks for version compatibility when at least one specifies
-    an exact version
+    Checks for version compatibility when the dependency for
+    'left_version' has specified an exact version
 
     Args:
-        setup_version (packaging.version.Version):
-            The version specified in setup.py
-        pipfile_op (str):
-            The comparison operation specified in the Pipfile
-        pipfile_version (packaging.version.Version):
-            The version specified in the Pipfile
+        left_version (packaging.version.Version):
+            The version on the left side of the comparison
+        right_op (str):
+            The comparison operator to be used, associated with 'right_version'
+        right_version (packaging.version.Version):
+            The version on the right side of the comparison
     Returns:
         bool: Whether or not the check passed
     """
-    return operators[pipfile_op](setup_version, pipfile_version)
+    return operators[right_op](left_version, right_version)
 
 
-def check_inequality(setup_version, pipfile_op, pipfile_version):
+def check_inequality(left_version, right_op, pipfile_version):
     """
-    Checks for version compatibility when at least one specifies
-    an explicitly disallowed version
+    Checks for version compatibility when the dependency for
+    'left_version' has specified an explicitly disallowed version
 
     Args:
-        setup_version (packaging.version.Version):
-            The version specified in setup.py
-        pipfile_op (str):
-            The comparison operation specified in the Pipfile
+        left_version (packaging.version.Version):
+            The version on the left side of the comparison
+        right_op (str):
+            The comparison operator to be used, associated with 'right_version'
         pipfile_version (packaging.version.Version):
             The version specified in the Pipfile
     Returns:
         bool: Whether or not the check passed
     """
     inclusive_ops = ["==", ">=", "=>", "<="]
-    return not (pipfile_op in inclusive_ops and
-                setup_version == pipfile_version)
+    return not (right_op in inclusive_ops and
+                left_version == pipfile_version)
 
 
-def check_range(setup_op, setup_version, pipfile_op, pipfile_version):
+def check_range(left_op, left_version, right_op, right_version):
     """
-    Checks for version compatibility when at least one specifies
-    an exact version
+    Checks for version compatibility when the dependency for 'left_version'
+    has specified a version range
 
     Args:
-        setup_op (str):
-            The comparison operation specified in setup.py
-        setup_version (packaging.version.Version):
-            The version specified in setup.py
-        pipfile_op (str):
-            The comparison operation specified in the Pipfile
-        pipfile_version (packaging.version.Version):
-            The version specified in the Pipfile
+        left_op (str):
+            A comparison operator, associated with 'left_version'
+        left_version (packaging.version.Version):
+            The version on the left side of the comparison
+        right_op (str):
+            A comparison operator, associated with 'right_version'
+        right_version (packaging.version.Version):
+            The version on the right side of the comparison
     Returns:
         bool: Whether or not the check passed
     """
     gt_ops = [">", ">=", "=>"]
     lt_ops = ["<", "<="]
 
-    same_op_class = ((setup_op in gt_ops and pipfile_op in gt_ops) or
-                     (setup_op in lt_ops and pipfile_op in lt_ops))
+    same_op_class = ((left_op in gt_ops and right_op in gt_ops) or
+                     (left_op in lt_ops and right_op in lt_ops))
     if same_op_class:
         return True
-    return (operators[setup_op](pipfile_version, setup_version) and
-            operators[pipfile_op](setup_version, pipfile_version))
+    elif right_op == "==":
+        return check_equality(right_version, left_op, left_version)
+    elif right_op == "!=":
+        return check_inequality(right_version, left_op, left_version)
+    else:
+        return (operators[left_op](right_version, left_version) and
+                operators[right_op](left_version, right_version))
 
 
 # Mapping from operator strings to comparison functions

--- a/pipenv_devcheck/pipenv_setup_comp.py
+++ b/pipenv_devcheck/pipenv_setup_comp.py
@@ -201,19 +201,19 @@ def version_check(setup_deps, pipfile_deps):
                 setup_version = parse_version(setup_dep_spec[1])
 
                 check_fn = check_fn_mapping[setup_op]
-                check_args = {}
+                check_args = []
                 if setup_op not in ["==", "!="]:
-                    check_args["setup_op"] = setup_op
-                check_args["setup_version"] = setup_version
+                    check_args.append(setup_op)
+                check_args.append(setup_version)
 
                 for pipfile_dep_spec in pipfile_dep_specs:
                     pipfile_op = pipfile_dep_spec[0]
                     if not pipfile_op == "*":
                         pipfile_version = parse_version(pipfile_dep_spec[1])
-                        check_args["pipfile_op"] = pipfile_op
-                        check_args["pipfile_version"] = pipfile_version
+                        check_args.append(pipfile_op)
+                        check_args.append(pipfile_version)
 
-                        if not check_fn(**check_args):
+                        if not check_fn(*check_args):
                             problem_deps.append(dep_name)
 
     if len(problem_deps):

--- a/pipenv_devcheck/pipenv_setup_comp.py
+++ b/pipenv_devcheck/pipenv_setup_comp.py
@@ -201,19 +201,18 @@ def version_check(setup_deps, pipfile_deps):
                 setup_version = parse_version(setup_dep_spec[1])
 
                 check_fn = check_fn_mapping[setup_op]
-                check_args = []
-                if setup_op not in ["==", "!="]:
-                    check_args.append(setup_op)
-                check_args.append(setup_version)
+                check_args = {}
+                check_args["left_op"] = setup_op
+                check_args["left_version"] = setup_version
 
                 for pipfile_dep_spec in pipfile_dep_specs:
                     pipfile_op = pipfile_dep_spec[0]
                     if not pipfile_op == "*":
                         pipfile_version = parse_version(pipfile_dep_spec[1])
-                        check_args.append(pipfile_op)
-                        check_args.append(pipfile_version)
-
-                        if not check_fn(*check_args):
+                        check_args["right_op"] = pipfile_op
+                        check_args["right_version"] = pipfile_version
+                        print(check_args)
+                        if not check_fn(**check_args):
                             problem_deps.append(dep_name)
 
     if len(problem_deps):

--- a/test/test_check_fns.py
+++ b/test/test_check_fns.py
@@ -31,9 +31,10 @@ def test_invalid_range():
 
 def test_valid_equality():
     """
-    Tests that compatible version equalities pass checks
+    Tests that compatible version equalities pass checks -
+    includes a case where 'left_op' if provided
     """
-    assert check_equality(left_version="1.2.3", left_op='==', 
+    assert check_equality(left_version="1.2.3", left_op='==',
                           right_op="<", right_version="3.2.1")
     assert check_equality("1.2.3", "==", "1.2.3")
 

--- a/test/test_check_fns.py
+++ b/test/test_check_fns.py
@@ -33,7 +33,8 @@ def test_valid_equality():
     """
     Tests that compatible version equalities pass checks
     """
-    assert check_equality("1.2.3", "<", "3.2.1")
+    assert check_equality(left_version="1.2.3", left_op='==', 
+                          right_op="<", right_version="3.2.1")
     assert check_equality("1.2.3", "==", "1.2.3")
 
 

--- a/test/test_check_fns.py
+++ b/test/test_check_fns.py
@@ -34,7 +34,7 @@ def test_valid_equality():
     Tests that compatible version equalities pass checks -
     includes a case where 'left_op' if provided
     """
-    assert check_equality(left_version="1.2.3", left_op='==',
+    assert check_equality(left_op='==', left_version="1.2.3",
                           right_op="<", right_version="3.2.1")
     assert check_equality("1.2.3", "==", "1.2.3")
 
@@ -49,9 +49,11 @@ def test_invalid_equality():
 
 def test_valid_inequality():
     """
-    Tests that compatible version inequalities pass checks
+    Tests that compatible version inequalities pass checks -
+    includes a case where 'left_op' if provided
     """
-    assert check_inequality("1.2.3", ">", "1.2.3")
+    assert check_inequality(left_op="!=", left_version="1.2.3",
+                            right_op=">", right_version="1.2.3")
     assert check_inequality("1.2.3", "==", "4.5.6")
 
 


### PR DESCRIPTION
Fixed bug that caused situations where equality (`==`) in the Pipfile combined
with a range operator would lead to detection of nonexistent discrepancies.