### PR TITLE
DE-116 | Add Support for Package Extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for package extras
+
 ### Changed
 - Switched to standard NHDS CI pipeline
 

--- a/pipenv_devcheck/pipenv_setup_comp.py
+++ b/pipenv_devcheck/pipenv_setup_comp.py
@@ -4,7 +4,9 @@ import pipfile
 import re
 
 from pipenv_devcheck.check_fns import check_fn_mapping
-from pipenv_devcheck.regexps import setup_exp, spec_exp, split_exp
+from pipenv_devcheck.regexps import (setup_spec_exp, setup_extras_exp,
+                                     setup_extras_w_name_exp,
+                                     spec_exp, split_exp)
 
 
 def compare_deps():
@@ -15,9 +17,9 @@ def compare_deps():
         tuple<dict<str, list<tuple<str, str>>>:
             Dictionaries of the dependencies found in setup.py and the Pipfile
     """
-    setup_deps = get_setup_deps()
-    pipfile_deps = get_pipfile_deps()
-    run_checks(setup_deps, pipfile_deps)
+    setup_deps, setup_extras = get_setup_deps()
+    pipfile_deps, pipfile_extras = get_pipfile_deps()
+    run_checks(setup_deps, setup_extras, pipfile_deps, pipfile_extras)
     return setup_deps, pipfile_deps
 
 
@@ -32,9 +34,22 @@ def get_setup_deps():
     """
     setup_deps_str = read_setup()
 
+    setup_extras = {}
+    for i in range(len(setup_deps_str)):
+        current_dep_str = setup_deps_str[i]
+        extras_match = re.search(setup_extras_exp, current_dep_str)
+        if extras_match:
+            extras_info = re.findall(setup_extras_w_name_exp,
+                                     current_dep_str)[0]
+            dep = extras_info[0]
+            extras = [extra.strip() for extra in extras_info[1].split(',')]
+            setup_extras[dep] = extras
+
+            setup_deps_str[i] = (current_dep_str[:extras_match.start()] +
+                                 current_dep_str[extras_match.end():])
     setup_deps = {}
     for dep in setup_deps_str:
-        parsed_dep = re.findall(setup_exp, dep)
+        parsed_dep = re.findall(setup_spec_exp, dep)
         if len(parsed_dep):
             parsed_dep = parsed_dep[0]
             setup_deps.update({parsed_dep[0]: [spec for spec in parsed_dep[1:]
@@ -43,7 +58,7 @@ def get_setup_deps():
             setup_deps.update({dep: ["*"]})
 
     setup_deps = split_ops_and_versions(setup_deps)
-    return setup_deps
+    return setup_deps, setup_extras
 
 
 def read_setup():
@@ -79,15 +94,19 @@ def get_pipfile_deps():
             Dictionaries of the dependencies found in the Pipfile
     """
     pipfile_deps = read_pipfile()
+
+    pipfile_extras = {}
     for dep in pipfile_deps.keys():
         dep_spec = pipfile_deps[dep]
         if isinstance(dep_spec, dict):
+            if 'extras' in dep_spec:
+                pipfile_extras[dep] = dep_spec['extras']
             dep_spec = dep_spec['version']
         pipfile_deps[dep] = re.findall(spec_exp, dep_spec)
 
     pipfile_deps = split_ops_and_versions(pipfile_deps)
 
-    return pipfile_deps
+    return pipfile_deps, pipfile_extras
 
 
 def read_pipfile():
@@ -125,12 +144,34 @@ def split_ops_and_versions(deps):
     return deps
 
 
-def run_checks(setup_deps, pipfile_deps):
+def run_checks(setup_deps, setup_extras, pipfile_deps, pipfile_extras):
     """
     Runs all currently implemented checks
     """
     name_equality_check(setup_deps, pipfile_deps)
     version_check(setup_deps, pipfile_deps)
+    extras_equality_check(setup_extras, pipfile_extras)
+
+
+def extras_equality_check(setup_extras, pipfile_extras):
+    if setup_extras.keys() != pipfile_extras.keys():
+        setup_deps = set(setup_extras.keys())
+        pipfile_deps = set(pipfile_extras.keys())
+        raise KeyError('There is a discrepancy in what packages have extras '
+                       'specified between setup.py and the Pipfile. '
+                       'Packages involved in discrepancy: '
+                       ', '.join(setup_deps.symmetric_difference(pipfile_deps))
+                       )
+
+    deps_w_mismatched_extras = []
+    for dep in setup_extras.keys():
+        if setup_extras[dep] != pipfile_extras[dep]:
+            deps_w_mismatched_extras.append(dep)
+
+    if deps_w_mismatched_extras:
+        raise ValueError('The following dependencies have mismatched '
+                         'package extras between setup.py and the Pipfile: '
+                         ', '.join(deps_w_mismatched_extras))
 
 
 def name_equality_check(setup_deps, pipfile_deps):

--- a/pipenv_devcheck/pipenv_setup_comp.py
+++ b/pipenv_devcheck/pipenv_setup_comp.py
@@ -93,7 +93,7 @@ def get_pipfile_deps():
 
     Returns:
         pipfile_deps (dict<str, list<tuple<str, str>>>):
-            Dictionaryof the dependencies found in the Pipfile
+            Dictionary of the dependencies found in the Pipfile
         pipfile_extras (dict<str, list<str>>):
             Dictionary of extras specified in the Pipfile
     """

--- a/pipenv_devcheck/regexps.py
+++ b/pipenv_devcheck/regexps.py
@@ -12,6 +12,7 @@ ops_exp += ")"
 # TODO - Add support for letters, like in beta releases?
 version_exp = r"[\d.]+"
 
+# Captures the name of a package
 package_name_exp = r"([\w|\-]*)"
 # Captures a full specification - an operator and a version.
 spec_exp = r"(\s*" + ops_exp + r"\s*" + version_exp + "|\\*)"
@@ -28,5 +29,7 @@ setup_spec_exp = (
     addtl_spec_exp
 )
 
+# Captures extras included in dependencies in setup.py
 setup_extras_exp = r'(?:\[([\w\-, ]*)\])'
+# Catures extras included in dependencies in setup.py, including package names
 setup_extras_w_name_exp = package_name_exp + setup_extras_exp

--- a/pipenv_devcheck/regexps.py
+++ b/pipenv_devcheck/regexps.py
@@ -12,6 +12,7 @@ ops_exp += ")"
 # TODO - Add support for letters, like in beta releases?
 version_exp = r"[\d.]+"
 
+package_name_exp = r"([\w|\-]*)"
 # Captures a full specification - an operator and a version.
 spec_exp = r"(\s*" + ops_exp + r"\s*" + version_exp + "|\\*)"
 # Captures a full specification, capturing the operator and version separately
@@ -20,9 +21,12 @@ split_exp = "(" + ops_exp + r")\s*(" + version_exp + ")"
 addtl_spec_exp = r"(?:," + spec_exp + ")?"
 
 # Full expression for matching dependencies in setup.py
-setup_exp = (
-    r"([\w|\-]*)" +
+setup_spec_exp = (
+    package_name_exp +
     spec_exp +
     addtl_spec_exp +
     addtl_spec_exp
 )
+
+setup_extras_exp = r'(?:\[([\w\-, ]*)\])'
+setup_extras_w_name_exp = package_name_exp + setup_extras_exp

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,8 +16,8 @@ setup(
         packages=find_packages(),
         install_requires=[
                 'matplotlib>=3.1.1',
-                'numpy>=1.17.2',
-                'pandas>=0.25.1',
+                'pyhive[hive, presto]>=0.6.0',
+                'pandas[fake_extra]>=0.25.1',
                 'seaborn>=0.9.0',
                 'simple_salesforce>=0.74.3'
         ]
@@ -30,23 +30,29 @@ def setup_deps_from_read():
     """setup.py dependencies extracted from a string into a dict"""
     return [
         'matplotlib>=3.1.1',
-        'numpy>=1.17.2',
-        'pandas>=0.25.1',
+        'pyhive[hive, presto]>=0.6.0',
+        'pandas[fake_extra]>=0.25.1',
         'seaborn>=0.9.0',
         'simple_salesforce>=0.74.3'
     ]
 
 
 @pytest.fixture()
-def setup_deps():
+def setup_deps_and_extras():
     """setup.py dependencies extracted from a string into a dict"""
-    return {
+    return (
+        {
             "matplotlib": [(">=", "3.1.1")],
-            "numpy": [(">=", "1.17.2")],
+            "pyhive": [(">=", "0.6.0")],
             "pandas": [(">=", "0.25.1")],
             "seaborn": [(">=", "0.9.0")],
             "simple_salesforce": [(">=", "0.74.3")]
-    }
+        },
+        {
+            "pyhive": ["hive", "presto"],
+            "pandas": ["fake_extra"]
+        }
+    )
 
 
 @pytest.fixture
@@ -60,8 +66,8 @@ verify_ssl = true
 
 [packages]
 matplotlib = ">=3.1.1, <=3.1.2"
-numpy = "==1.17.2"
-pandas = "==0.25.1"
+pyhive = {extras = ["hive", "presto"], version = "==0.6.1"}
+pandas = {extras = ["fake_extra"], version = "==0.25.1"}
 seaborn = "==0.9.0"
 simple_salesforce = "==0.74.3"
 
@@ -75,23 +81,29 @@ def pipfile_deps_from_read():
     """Pipfile dependencies extracted from a string into a dict"""
     return {
             "matplotlib": ">=3.1.1, <=3.1.2",
-            "numpy": "==1.17.2",
-            "pandas": "==0.25.1",
+            "pyhive": {"extras": ["hive", "presto"], "version": "==0.6.1"},
+            "pandas": {"extras": ["fake_extra"], "version": "==0.25.1"},
             "seaborn": "==0.9.0",
             "simple_salesforce": "==0.74.3"
     }
 
 
 @pytest.fixture
-def pipfile_deps():
+def pipfile_deps_and_extras():
     """Pipfile dependencies extracted from a string into a dict"""
-    return {
+    return (
+        {
             "matplotlib": [(">=", "3.1.1"), ("<=", "3.1.2")],
-            "numpy": [("==", "1.17.2")],
+            "pyhive": [("==", "0.6.1")],
             "pandas": [("==", "0.25.1")],
             "seaborn": [("==", "0.9.0")],
             "simple_salesforce": [("==", "0.74.3")]
-    }
+        },
+        {
+            "pyhive": ["hive", "presto"],
+            "pandas": ["fake_extra"]
+        }
+    )
 
 
 @pytest.fixture
@@ -99,8 +111,20 @@ def deps_unsplit():
     """Section of pipfile that is specific to dependencies"""
     return {
         "matplotlib": [">=3.1.1", "<=3.1.2"],
-        "numpy": ["==1.17.2"],
+        "pyhive": ["==0.6.1"],
         "pandas": ["==0.25.1"],
         "seaborn": ["==0.9.0"],
         "simple_salesforce": ["==0.74.3"]
+    }
+
+
+@pytest.fixture
+def test_extras():
+    """
+    A valid dict of extras as would be returned by 'get_setup_deps'
+    or 'get_pipfile_deps'
+    """
+    return {
+        'pyhive': ['hive', 'presto'],
+        'testpackage': ['extra0', 'extra1']
     }

--- a/test/test_pipenv_setup_comp.py
+++ b/test/test_pipenv_setup_comp.py
@@ -2,7 +2,8 @@ import pytest
 
 from pipenv_devcheck.pipenv_setup_comp import (
     read_setup, read_pipfile, get_setup_deps, get_pipfile_deps,
-    split_ops_and_versions, name_equality_check, version_check)
+    split_ops_and_versions, name_equality_check, version_check,
+    extras_equality_check)
 
 
 def test_read_setup(mocker, setup_text, setup_deps_from_read):
@@ -20,38 +21,42 @@ def test_read_pipfile(mocker, pipfile_text, pipfile_deps_from_read):
     """
     mocker.patch("builtins.open", mocker.mock_open(read_data=pipfile_text))
     read_results = read_pipfile()
+    print(read_results)
     assert read_results == pipfile_deps_from_read
 
 
-def test_get_setup_deps(mocker, setup_deps_from_read, setup_deps):
+def test_get_setup_deps(mocker, setup_deps_from_read, setup_deps_and_extras):
     """
     Tests that dependencies are properly read and parsed from a setup.py file
 
     Args:
-        setup_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        setup_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                               pytest.fixture):
             setup.py dependencies extracted from a string into a dict
     """
     mocker.patch("pipenv_devcheck.pipenv_setup_comp.read_setup",
                  return_value=setup_deps_from_read)
-    actual_deps = get_setup_deps()
-    assert actual_deps == setup_deps
+    actual_deps_and_extras = get_setup_deps()
+    assert actual_deps_and_extras == setup_deps_and_extras
 
 
-def test_get_pipfile_deps(mocker, pipfile_deps_from_read, pipfile_deps):
+def test_get_pipfile_deps(mocker, pipfile_deps_from_read,
+                          pipfile_deps_and_extras):
     """
     Tests that dependencies are properly read and parsed from a Pipfile
 
     Args:
-        pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        pipfile_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                                 pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
     mocker.patch("pipenv_devcheck.pipenv_setup_comp.read_pipfile",
                  return_value=pipfile_deps_from_read)
-    actual_deps = get_pipfile_deps()
-    assert actual_deps == pipfile_deps
+    actual_deps_and_extras = get_pipfile_deps()
+    assert actual_deps_and_extras == pipfile_deps_and_extras
 
 
-def test_split_ops_and_versions(deps_unsplit, pipfile_deps):
+def test_split_ops_and_versions(deps_unsplit, pipfile_deps_and_extras):
     """
     Tests that dependency specification strings (operator and version) are
     properly split into a tuple
@@ -60,37 +65,49 @@ def test_split_ops_and_versions(deps_unsplit, pipfile_deps):
         deps_from_read (dict<str, list<str>>, pytest.fixture):
             Dependencies as they would be returned by
             either read_setup or read_pipfile
-        pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        pipfile_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                                 pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
+    pipfile_deps = pipfile_deps_and_extras[0]
     actual_deps = split_ops_and_versions(deps_unsplit)
     assert actual_deps == pipfile_deps
 
 
-def test_name_equality_check_valid(setup_deps, pipfile_deps):
+def test_name_equality_check_valid(setup_deps_and_extras,
+                                   pipfile_deps_and_extras):
     """
     Tests that no errors are raised when no name discrepancies are present
 
     Args:
-        setup_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        setup_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                               pytest.fixture):
             setup.py dependencies extracted from a string into a dict
-        pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        pipfile_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                                 pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
+    setup_deps = setup_deps_and_extras[0]
+    pipfile_deps = pipfile_deps_and_extras[0]
     assert name_equality_check(setup_deps, pipfile_deps)
 
 
-def test_name_equality_check_in_setup_not_pipfile(setup_deps, pipfile_deps):
+def test_name_equality_check_in_setup_not_pipfile(setup_deps_and_extras,
+                                                  pipfile_deps_and_extras):
     """
     Checks that the proper errors are raised when a dependency name is present
     in setup.py but not in the Pipfile
 
     Args:
-        setup_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        setup_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                               pytest.fixture):
             setup.py dependencies extracted from a string into a dict
-        pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        pipfile_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                                 pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
+    setup_deps = setup_deps_and_extras[0]
+    pipfile_deps = pipfile_deps_and_extras[0]
     del pipfile_deps["pandas"]
 
     with pytest.raises(ValueError) as excinfo:
@@ -100,17 +117,21 @@ def test_name_equality_check_in_setup_not_pipfile(setup_deps, pipfile_deps):
     assert excinfo.match("pandas")
 
 
-def test_name_equality_check_in_pipfile_not_setup(setup_deps, pipfile_deps):
+def test_name_equality_check_in_pipfile_not_setup(setup_deps_and_extras,
+                                                  pipfile_deps_and_extras):
     """
     Checks that the proper errors are raised when a dependency name is present
     in the Pipfile but not in setup.py
 
     Args:
-        setup_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        setup_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                               pytest.fixture):
             setup.py dependencies extracted from a string into a dict
         pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
+    setup_deps = setup_deps_and_extras[0]
+    pipfile_deps = pipfile_deps_and_extras[0]
     del setup_deps["seaborn"]
 
     with pytest.raises(ValueError) as excinfo:
@@ -120,17 +141,22 @@ def test_name_equality_check_in_pipfile_not_setup(setup_deps, pipfile_deps):
     assert excinfo.match("seaborn")
 
 
-def test_name_equality_check_dual_mismatch(setup_deps, pipfile_deps):
+def test_name_equality_check_dual_mismatch(setup_deps_and_extras,
+                                           pipfile_deps_and_extras):
     """
     Checks that the correct errors are raised when there is a two-sided
     discrepancy in dependency names
 
     Args:
-        setup_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        setup_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                               pytest.fixture):
             setup.py dependencies extracted from a string into a dict
-        pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        pipfile_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                                 pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
+    setup_deps = setup_deps_and_extras[0]
+    pipfile_deps = pipfile_deps_and_extras[0]
     del setup_deps["pandas"]
     del pipfile_deps["matplotlib"]
 
@@ -144,29 +170,37 @@ def test_name_equality_check_dual_mismatch(setup_deps, pipfile_deps):
     assert excinfo.match(r"not in Pipfile:\W*matplotlib")
 
 
-def test_version_check_valid(setup_deps, pipfile_deps):
+def test_version_check_valid(setup_deps_and_extras, pipfile_deps_and_extras):
     """
     Tests that the version_check passes in a valid situation
 
     Args:
-        setup_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        setup_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                               pytest.fixture):
             setup.py dependencies extracted from a string into a dict
-        pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        pipfile_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                                 pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
+    setup_deps = setup_deps_and_extras[0]
+    pipfile_deps = pipfile_deps_and_extras[0]
     assert version_check(setup_deps, pipfile_deps)
 
 
-def test_version_check_invalid(setup_deps, pipfile_deps):
+def test_version_check_invalid(setup_deps_and_extras, pipfile_deps_and_extras):
     """
     Tests that the version_check fails in an invalid situation
 
     Args:
-        setup_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        setup_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                               pytest.fixture):
             setup.py dependencies extracted from a string into a dict
-        pipfile_deps (dict<str, list<tuple<str, str>>>), pytest.fixture):
+        pipfile_deps_and_extras (dict<str, list<tuple<str, str>>>),
+                                 pytest.fixture):
             Pipfile dependencies extracted from a string into a dict
     """
+    setup_deps = setup_deps_and_extras[0]
+    pipfile_deps = pipfile_deps_and_extras[0]
     pipfile_deps["pandas"][0] = ("<", "0.25.1")
     pipfile_deps["seaborn"][0] = ("<", "0.8.0")
 
@@ -176,3 +210,51 @@ def test_version_check_invalid(setup_deps, pipfile_deps):
     excinfo.match("pandas")
     excinfo.match("seaborn")
     excinfo.match("pandas, seaborn")
+
+
+def test_extras_equality_check_valid(test_extras):
+    """
+    Tests that the extras_equality_check passes in a valid situation.
+
+    Args:
+        test_extras (dict<str, str>, pytest.fixture):
+            A valid dict of package extras as would be passed to
+            'extras_equality_check'
+    """
+    assert extras_equality_check(test_extras, test_extras)
+
+
+def test_extras_equality_check_invalid_missingdep(test_extras):
+    """
+    Tests that the extras_equality_check fails when there is a difference
+    in which packages have extras specified
+
+    Args:
+        test_extras (dict<str, str>, pytest.fixture):
+            A valid dict of package extras as would be passed to
+            'extras_equality_check'
+    """
+    setup_extras = test_extras.copy()
+    del setup_extras['testpackage']
+    pipenv_extras = test_extras.copy()
+    with pytest.raises(KeyError,
+                       match='discrepancy in what packages have extras'):
+        assert extras_equality_check(setup_extras, pipenv_extras)
+
+
+def test_extras_equality_check_invalid_mismatched_extras(test_extras):
+    """
+    Tests that the extras_equality_check fails when the packages with extras
+    match, but the extras themselves differ
+
+    Args:
+        test_extras (dict<str, str>, pytest.fixture):
+            A valid dict of package extras as would be passed to
+            'extras_equality_check'
+    """
+    setup_extras = test_extras.copy()
+    setup_extras['pyhive'] = ['hive']
+    pipenv_extras = test_extras.copy()
+    with pytest.raises(ValueError,
+                       match='mismatched package extras'):
+        assert extras_equality_check(setup_extras, pipenv_extras)


### PR DESCRIPTION
Added support for package extras. Previously, packages with extras specified would have led to name mismatches or syntax errors during a standard check.